### PR TITLE
添加家庭住址转区划代码

### DIFF
--- a/xgdYqtb/xgd.py
+++ b/xgdYqtb/xgd.py
@@ -3,6 +3,7 @@ from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_v1_5
 import base64
 from lxml import etree
+import json
 import os
 import re
 try:
@@ -46,17 +47,53 @@ class XgdYqtb(object):
             '_eventId': 'submit'
         })
 
+    def get_csbm(self, cs):
+        # 转data.js内容为python dict,区划代码字典
+        res = self.session.get(
+            'http://yqtb.nwpu.edu.cn/wx/js/eams.area.data.js')
+        region_data_re = re.compile(r'var placesMap=(?P<addr>.*) ;')
+        region_dict = region_data_re.match(res.text).group('addr')
+        region_dict = json.loads(region_dict)
+        # 根据正则切割连续字符串，填报系统总是三段信息组成
+        fullname_re = re.compile(
+            r'(?P<province>[^省]+自治区|.*?省|.*?行政区|.*?市)(?P<city>[^市]+自治州|.*?地区|.*?行政单位|.+盟|市辖区|.*?市|.*?县)(?P<county>[^县]+县|.+区|.+市|.+旗|.+海域|.+岛)?')
+        try:
+            re_result = fullname_re.match(cs)
+        except Exception as e:
+            print("城市匹配失败", cs, e)
+            return None
+
+        provice = re_result.group('province')
+        city = re_result.group('city')
+        county = re_result.group('county')
+        addr_list = [provice, city, county]
+
+        """根据县搜索code，存在重复项则依据市信息检索，市信息唯一
+        但对于直辖市，其第二级名称总是市辖区、县，重复，需另行判断
+        """
+        country_search_result = []
+        for code, addr in region_dict.items():
+            if addr == addr_list[-1]:
+                country_search_result.append(int(code))
+        # 唯一匹配直接返回
+        if len(country_search_result) == 0:
+            raise IndexError
+        if len(country_search_result) == 1:
+            return country_search_result[0]
+        if addr_list[1] in ["市辖区", "县"]:
+            # 比较省名称
+            for code in country_search_result:
+                provice = int(code/10000)*10000
+                if region_dict[str(provice)] == addr_list[0]:
+                    return code
+        else:
+            for code in country_search_result:
+                city = int(code/100)*100
+                if region_dict[str(city)] == addr_list[1]:
+                    return code
+
     def get_personal_info(self, skey):
         def init_info():
-            def get_csbm(cs):
-                res = self.session.get(
-                    'http://yqtb.nwpu.edu.cn/wx/js/eams.area.data.js')
-                match = re.search('"([0-9]+)":"'+cs+'"', res.text, re.M)
-                try:
-                    return match.group(1)
-                except Exception as e:
-                    print("城市匹配失败", cs, e)
-                    return ''
             res = self.session.get(
                 'http://yqtb.nwpu.edu.cn/wx/xg/yz-mobile/userInfo.jsp')
             res_tree = etree.HTML(res.text)
@@ -72,7 +109,10 @@ class XgdYqtb(object):
                     else:
                         cell_value = value_xpath[0]
                     self.info[cell_key] = cell_value
-                self.info['csbm'] = get_csbm(self.info['家庭地址'].split()[-1])
+                csbm = self.get_csbm(self.info['家庭地址'])
+                # print("获取csdm成功")
+                if csbm:
+                    self.info['csbm'] = csbm
                 # print(self.info)
             except Exception as e:
                 print("获取个人信息失败", e)


### PR DESCRIPTION
现有学校接口中，地址不再以空格划分，导致区划代码获取异常，所以我添加了以下功能：
- 正则划分整个字符串为省、市、县三级
- 提取areas为json，根据县级名称查找对应区划代码
- 遇到重名的县，根据上一级再次筛选
- by 528-lkh